### PR TITLE
fix: update 5xx error alarm thresholds and evaluation periods

### DIFF
--- a/src/main/33-api-user-registry.tf
+++ b/src/main/33-api-user-registry.tf
@@ -194,11 +194,11 @@ module "api_user_registry_5xx_error_alarm" {
   alarm_name          = "high-5xx-rate-"
   alarm_description   = "${local.runbook_title} ${local.runbook_url} Api user registry error rate has exceeded the threshold."
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
-  threshold           = 0
+  evaluation_periods  = 3
+  threshold           = 1
   period              = 300
   unit                = "Count"
-  datapoints_to_alarm = 1
+  datapoints_to_alarm = 2
 
   namespace   = "AWS/ApiGateway"
   metric_name = "5XXError"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
-Updated the CloudWatch alarm configuration for the API User Registry 5xx error alarm:
-- evaluation_periods from 2 to 3;
-- datapoints_to_alarm from 1 to 2;

This change prevents alarms caused by transient errors.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x ] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-infra.deploy](https://dev.azure.com/pagopaspa/io-iac-projects/_build?definitionId=218)
2. select PR branch
3. wait for approval
